### PR TITLE
Membetulkan error status get invoice by id saat invoice not found 

### DIFF
--- a/backend/src/controllers/financialDocumentController.js
+++ b/backend/src/controllers/financialDocumentController.js
@@ -1,6 +1,6 @@
 const pdfValidationService = require('../services/pdfValidationService');
 const { safeResponse } = require('../utils/responseHelper');
-const { ValidationError, AuthError, ForbiddenError, PayloadTooLargeError, UnsupportedMediaTypeError } = require('../utils/errors');
+const { ValidationError, AuthError, ForbiddenError, PayloadTooLargeError, UnsupportedMediaTypeError, NotFoundError } = require('../utils/errors');
 
 class FinancialDocumentController {
   constructor(service, documentType) {
@@ -74,6 +74,9 @@ class FinancialDocumentController {
     }
     if (error instanceof ForbiddenError) {
       return safeResponse(res, 403, error.message);
+    }
+    if (error instanceof NotFoundError) {
+      return safeResponse(res, 404, error.message);
     }
     if (error instanceof PayloadTooLargeError) {
       return safeResponse(res, 413, error.message);

--- a/backend/src/services/invoice/invoiceService.js
+++ b/backend/src/services/invoice/invoiceService.js
@@ -11,6 +11,7 @@ const InvoiceResponseFormatter = require('./invoiceResponseFormatter');
 const { AzureInvoiceMapper } = require('../invoiceMapperService/invoiceMapperService');
 const InvoiceLogger = require('./invoiceLogger');
 const DocumentStatus = require('../../models/enums/DocumentStatus.js');
+const { NotFoundError } = require('../../utils/errors.js');
 
 class InvoiceService extends FinancialDocumentService {
   constructor() {
@@ -209,7 +210,7 @@ class InvoiceService extends FinancialDocumentService {
     const invoice = await this.invoiceRepository.findById(id);
 
     if (!invoice) {
-      throw new Error("Invoice not found");
+      throw new NotFoundError("Invoice not found");
     }
     return invoice.partner_id;
   }
@@ -219,7 +220,7 @@ class InvoiceService extends FinancialDocumentService {
       const invoice = await this.invoiceRepository.findById(id);
       
       if (!invoice) {
-        throw new Error("Invoice not found");
+        throw new NotFoundError("Invoice not found");
       }
 
       // Check invoice status first

--- a/backend/src/utils/errors.js
+++ b/backend/src/utils/errors.js
@@ -33,10 +33,18 @@ class UnsupportedMediaTypeError extends Error {
     }
 }
 
+class NotFoundError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "NotFoundError";
+    }
+}
+
 module.exports = {
     ValidationError,
     AuthError,
     ForbiddenError,
     PayloadTooLargeError,
-    UnsupportedMediaTypeError
+    UnsupportedMediaTypeError, 
+    NotFoundError
 };

--- a/backend/tests/controllers/financialDocumentController.test.js
+++ b/backend/tests/controllers/financialDocumentController.test.js
@@ -1,4 +1,5 @@
 const FinancialDocumentController = require("../../src/controllers/financialDocumentController");
+const { ValidationError, AuthError, ForbiddenError, PayloadTooLargeError, UnsupportedMediaTypeError, NotFoundError } = require("../../src/utils/errors");
 
 describe("FinancialDocumentController", () => {
   let controller;
@@ -27,6 +28,90 @@ describe("FinancialDocumentController", () => {
       await expect(controller.processUpload(mockReq)).rejects.toThrow(
         "processUpload must be implemented by child classes"
       );
+    });
+  });
+
+  describe("handleError", () => {
+    describe("handleError", () => {
+      test("should return 400 for ValidationError", () => {
+        const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+        const error = new ValidationError("Validation error");
+
+        controller.handleError(res, error);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ message: "Validation error" });
+      });
+
+      test("should return 401 for AuthError", () => {
+        const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+        const error = new AuthError("Unauthorized");
+
+        controller.handleError(res, error);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({ message: "Unauthorized" });
+      });
+
+      test("should return 403 for ForbiddenError", () => {
+        const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+        const error = new ForbiddenError("Forbidden");
+
+        controller.handleError(res, error);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith({ message: "Forbidden" });
+      });
+
+      test("should return 404 for NotFoundError", () => {
+        const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+        const error = new NotFoundError("Not found");
+
+        controller.handleError(res, error);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ message: "Not found" });
+      });
+
+      test("should return 413 for PayloadTooLargeError", () => {
+        const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+        const error = new PayloadTooLargeError("Payload too large");
+
+        controller.handleError(res, error);
+
+        expect(res.status).toHaveBeenCalledWith(413);
+        expect(res.json).toHaveBeenCalledWith({ message: "Payload too large" });
+      });
+
+      test("should return 415 for UnsupportedMediaTypeError", () => {
+        const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+        const error = new UnsupportedMediaTypeError("Unsupported media type");
+
+        controller.handleError(res, error);
+
+        expect(res.status).toHaveBeenCalledWith(415);
+        expect(res.json).toHaveBeenCalledWith({ message: "Unsupported media type" });
+      });
+
+      test("should return 504 for Timeout error", () => {
+        const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+        const error = new Error("Timeout");
+
+        controller.handleError(res, error);
+
+        expect(res.status).toHaveBeenCalledWith(504);
+        expect(res.json).toHaveBeenCalledWith({ message: "Server timeout - upload processing timed out" });
+      });
+
+      test("should return 500 for unexpected error", () => {
+        const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+        const error = new Error("Unexpected error");
+
+        controller.handleError(res, error);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ message: "Internal server error" });
+      });
     });
   });
 });


### PR DESCRIPTION
Error status yang tadinya 500, diganti menjadi 404 sesuai dengan PBI. Masalah terjadi di invoiceService, ketike tipe error yang dikembalikan adalah Error dan tidak terdeteksi di controller. 

PR ini membuat tipe error baru yaitu NotFoundError, kemudian mengganti error di invoiceService serta membaut handler di invoiceController. 