### PR TITLE
Hotfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     name: Deploy to Green Environment
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/staging' || 'refs/heads/deployment-2'
+    if: github.ref == 'refs/heads/staging'
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
@@ -380,7 +380,7 @@ jobs:
     name: Run Functional Tests on Green Environment
     runs-on: ubuntu-latest
     needs: deploy-green
-    if: github.ref == 'refs/heads/staging' || 'refs/heads/deployment-2'
+    if: github.ref == 'refs/heads/staging' 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -462,7 +462,7 @@ jobs:
     name: Deploy to Production (Blue)
     runs-on: ubuntu-latest
     needs: functional-test
-    if: github.ref == 'refs/heads/staging' || 'refs/heads/deployment-2'
+    if: github.ref == 'refs/heads/staging'
     permissions:
       contents: write # Add explicit permission to create releases
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,9 @@ jobs:
     name: Deploy to Green Environment
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/staging'
+    if: |
+      github.event_name == 'push' && github.ref == 'refs/heads/staging' ||
+      github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging'
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
@@ -380,7 +382,9 @@ jobs:
     name: Run Functional Tests on Green Environment
     runs-on: ubuntu-latest
     needs: deploy-green
-    if: github.ref == 'refs/heads/staging' 
+    if: |
+      github.event_name == 'push' && github.ref == 'refs/heads/staging' ||
+      github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -462,7 +466,9 @@ jobs:
     name: Deploy to Production (Blue)
     runs-on: ubuntu-latest
     needs: functional-test
-    if: github.ref == 'refs/heads/staging'
+    if: |
+      github.event_name == 'push' && github.ref == 'refs/heads/staging' ||
+      github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging'
     permissions:
       contents: write # Add explicit permission to create releases
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: |
-      github.event_name == 'push' && github.ref == 'refs/heads/staging' ||
-      github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging'
+      github.event_name == 'push' && github.ref == 'refs/heads/staging'
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
@@ -383,8 +382,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy-green
     if: |
-      github.event_name == 'push' && github.ref == 'refs/heads/staging' ||
-      github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging'
+      github.event_name == 'push' && github.ref == 'refs/heads/staging'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -467,8 +465,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: functional-test
     if: |
-      github.event_name == 'push' && github.ref == 'refs/heads/staging' ||
-      github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'staging'
+      github.event_name == 'push' && github.ref == 'refs/heads/staging'
     permissions:
       contents: write # Add explicit permission to create releases
     steps:


### PR DESCRIPTION
fix workflow: deploy only when pr or push to staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow conditions so that deployment and testing jobs now run only for push events on the staging branch. The deployment-2 branch is no longer included. No changes to application features or user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->